### PR TITLE
Update dependency version

### DIFF
--- a/.github/workflows/website_tests.yml
+++ b/.github/workflows/website_tests.yml
@@ -21,7 +21,7 @@ jobs:
     
     - name: Get Deployment URL
       id: get_deployment_url
-      uses: dorshinar/get-deployment-url@v1.0.4
+      uses: dorshinar/get-deployment-url@v1.0.5
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get Deployment URL
         id: get_deployment_url
-        uses: dorshinar/get-deployment-url@v1.0.4
+        uses: dorshinar/get-deployment-url@v1.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
The bug about all get-deployment-url runs failing until retried manually was fixed by https://github.com/dorshinar/get-deployment-url/pull/3 and pushed in v1.0.5