### PR TITLE
Fix broken blog link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -69,5 +69,6 @@ name = "Blog"
 url = "/posts"
 
 [taxonomies]
-tag = "tags"
-category = ""
+category = "blog"
+tag      = "tags"
+series   = "series"

--- a/config.toml
+++ b/config.toml
@@ -19,8 +19,8 @@ defaultTheme = "dark"
 [author]
 name = "Amrit Rathie"
 
-#[permalinks]
-#posts = "/posts/:year/:month/:day/:title/"
+[permalinks]
+posts = "/posts/:year/:month/:day/:title/"
 
 [params]
 dateform = "Jan 2, 2006"

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ languageCode = "en-us"
 title = "Amrit Rathie"
 theme = "hello-friend-ng"
 copyright = "Amrit Rathie"
-paginate = 1
+paginate = 8
 canonifyURLs = true
 enableRobotsTXT = true
 enableGitInfo = false
@@ -19,8 +19,8 @@ defaultTheme = "dark"
 [author]
 name = "Amrit Rathie"
 
-[permalinks]
-posts = "/posts/:year/:month/:day/:title/"
+#[permalinks]
+#posts = "/posts/:year/:month/:day/:title/"
 
 [params]
 dateform = "Jan 2, 2006"


### PR DESCRIPTION
This had to do with the `taxonomies` section of `config.toml`. Still not sure what this actually does. Probably worth looking into.